### PR TITLE
fix phenotype reader error message

### DIFF
--- a/src/interfaces/python/limix/io/phenotype_reader.py
+++ b/src/interfaces/python/limix/io/phenotype_reader.py
@@ -98,6 +98,13 @@ class pheno_reader_tables():
         elif phenotype_query is not None:
             try:
                 I = self.index_frame.query(phenotype_query).values[:,0]
+
+                #if there are no results we won't actually get an exception, we just get an
+                #empty response
+                if len(I) == 0:
+                    print "query '%s' yielded no results!" % (phenotype_query)
+                    I = SP.zeros([0],dtype="int")
+
             except Exception, arg:
                 
                 print "query '%s' yielded no results: %s" % (phenotype_query, str(arg))

--- a/src/interfaces/python/limix/io/phenotype_reader.py
+++ b/src/interfaces/python/limix/io/phenotype_reader.py
@@ -100,7 +100,7 @@ class pheno_reader_tables():
                 I = self.index_frame.query(phenotype_query).values[:,0]
             except Exception, arg:
                 
-                print "query '%s' yielded no results: %s"%phenotype_query, str(arg) 
+                print "query '%s' yielded no results: %s" % (phenotype_query, str(arg))
                                 
                 I = SP.zeros([0],dtype="int") 
         else:


### PR DESCRIPTION
Fixed typo in phenotype_reader that would cause an Exception if no phenotypes were found.