### PR TITLE
added categorical covariance

### DIFF
--- a/limix/core/covar/__init__.py
+++ b/limix/core/covar/__init__.py
@@ -11,3 +11,4 @@ from .cov3kronSumLR import Cov3KronSumLR
 from .covar_base import Covariance
 from .categoricalLR import CategoricalLR
 from .zkz import ZKZCov
+from .categorical import Categorical

--- a/limix/core/covar/categorical.py
+++ b/limix/core/covar/categorical.py
@@ -1,0 +1,83 @@
+from .covar_base import Covariance
+from limix.hcache import cached
+import numpy as np
+
+# TODO can we do import LowRankCov ?
+import lowrank
+import freeform
+
+
+class Categorical(Covariance):
+    """
+    Categorical covariance.
+    cov_{i,j} depends on the category of i and j only
+
+    Main members of the class:
+        - categories: a vector of length the dimension of the cov matrix with the
+        categories to which every sample belongs
+        - cat_cov, a covariance matrix between categories, whose dimensions are determined
+        by the number of categories -> can be free form or low rank
+    """
+    def __init__(self, categories, rank=None):
+        Covariance.__init__(self)
+
+        self.categories = categories
+        self.unique_categories = np.unique(categories)
+        self.n_categories = len(self.unique_categories)
+        self.rank = rank
+        self.dim = len(self.categories)
+
+        # initialise covariance matrix between categories
+        self.initialize_cov()
+        # build a categories_num vector where categories are integers from 0 to number of categories
+        self.initialize_cats()
+
+    def initialize_cov(self):
+        if self.rank is None:
+            self.cat_cov = freeform.FreeFormCov(self.n_categories)
+        else:
+            self.cat_cov = lowrank.LowRankCov(self.n_categories, self.rank)
+
+    def initialize_cats(self):
+        self.i_categories = np.zeros(len(self.categories))
+        for i in range(self.unique_categories):
+            self.i_categories += (self.categories == self.unique_categories[i])*i
+
+
+    #####################
+    # Params handling
+    #####################
+    def setParams(self, params):
+        self.cat_cov.setParams(params)
+
+    def getParams(self):
+        return self.cat_cov.getParams()
+
+    def getNumberParams(self):
+        return self.cat_cov.getNumberParams()
+
+    #####################
+    # Cached
+    #####################
+    @cached('covar_base')
+    def K(self):
+        _K = self.cat_cov.K()
+        return self.expand(_K)
+
+    @cached('covar_base')
+    def K_grad_i(self, i):
+        _grad = self.cat_cov.K_grad_i(i)
+        return self.expand(_grad)
+
+    # TODO: hessian ? not implemented for lowrank
+
+    #####################
+    # Expanding the category * category matrices
+    #####################
+    def expand(self, mat):
+        R = np.zeros([self.dim, self.dim])
+        for i in range(self.n_categories):
+            for j in range(self.n_categories):
+                tmp_i = (self.i_categories == i)[:, None]
+                tmp_j = (self.i_categories == j)[None, :]
+                R += tmp_i.dot(tmp_j) * mat[i,j]

--- a/limix/core/covar/categorical.py
+++ b/limix/core/covar/categorical.py
@@ -40,9 +40,8 @@ class Categorical(Covariance):
 
     def initialize_cats(self):
         self.i_categories = np.zeros(len(self.categories))
-        for i in range(self.unique_categories):
+        for i in range(self.n_categories):
             self.i_categories += (self.categories == self.unique_categories[i])*i
-
 
     #####################
     # Params handling
@@ -57,22 +56,21 @@ class Categorical(Covariance):
         return self.cat_cov.getNumberParams()
 
     #####################
-    # Cached
+    # cov and gradient
     #####################
-    @cached('covar_base')
     def K(self):
-        _K = self.cat_cov.K()
-        return self.expand(_K)
+        R = self.cat_cov.K()
+        return self.expand(R)
 
-    @cached('covar_base')
     def K_grad_i(self, i):
-        _grad = self.cat_cov.K_grad_i(i)
-        return self.expand(_grad)
+        R = self.cat_cov.K_grad_i(i)
+        return self.expand(R)
 
     # TODO: hessian ? not implemented for lowrank
 
     #####################
     # Expanding the category * category matrices
+    # DO NOT CACHE here (cached in member cat_cov)
     #####################
     def expand(self, mat):
         R = np.zeros([self.dim, self.dim])
@@ -81,3 +79,4 @@ class Categorical(Covariance):
                 tmp_i = (self.i_categories == i)[:, None]
                 tmp_j = (self.i_categories == j)[None, :]
                 R += tmp_i.dot(tmp_j) * mat[i,j]
+        return R

--- a/limix/core/covar/categorical.py
+++ b/limix/core/covar/categorical.py
@@ -57,6 +57,7 @@ class Categorical(Covariance):
 
     #####################
     # cov and gradient
+    # DO NOT CACHE here (cached in member cat_cov)
     #####################
     def K(self):
         R = self.cat_cov.K()
@@ -70,7 +71,6 @@ class Categorical(Covariance):
 
     #####################
     # Expanding the category * category matrices
-    # DO NOT CACHE here (cached in member cat_cov)
     #####################
     def expand(self, mat):
         R = np.zeros([self.dim, self.dim])

--- a/limix/core/covar/lowrank.py
+++ b/limix/core/covar/lowrank.py
@@ -112,6 +112,8 @@ class LowRankCov(Covariance):
         R += R.T
         return R
 
+    # TODO hessian ?
+
     ####################
     # TODO: Interpretable Params
     ####################

--- a/limix/core/covar/sqexp.py
+++ b/limix/core/covar/sqexp.py
@@ -16,8 +16,8 @@ class SQExpCov(Covariance):
     """
     def __init__(self, X, Xstar=None):
         """
-        X:          [dim, 1] input matrix
-        Xstar:      [dim_star, 1] out-of-sample input matrix
+        X:          [dim, N] input matrix
+        Xstar:      [dim_star, N] out-of-sample input matrix
         """
         Covariance.__init__(self)
         self._scale_act = True

--- a/limix/core/covar/test/test_categorical.py
+++ b/limix/core/covar/test/test_categorical.py
@@ -1,0 +1,48 @@
+"""LMM testing code"""
+import unittest
+import scipy as sp
+import numpy as np
+from limix.core.covar import Categorical
+from limix.utils.check_grad import mcheck_grad
+
+class TestCategorical(unittest.TestCase):
+    """test class for Categorical cov"""
+    def setUp(self):
+        # sp.random.seed(1)
+        self.n = 30
+        categories = sp.random.choice(['a', 'b', 'c'], self.n)
+
+        self.rank =2
+
+        self.C = Categorical(categories,self.rank)
+        self.name = 'categorical'
+        self.C.setRandomParams()
+
+    def test_grad(self):
+        def func(x, i):
+            self.C.setParams(x)
+            return self.C.K()
+
+        def grad(x, i):
+            self.C.setParams(x)
+            return self.C.K_grad_i(i)
+
+        x0 = self.C.getParams()
+        err = mcheck_grad(func, grad, x0)
+
+        np.testing.assert_almost_equal(err, 0., decimal = 6)
+
+    # def test_param_activation(self):
+    #     self.assertEqual(len(self.C.getParams()), 8)
+    #     self.C.act_X = False
+    #     self.assertEqual(len(self.C.getParams()), 0)
+    #
+    #     self.C.setParams(np.array([]))
+    #     with self.assertRaises(ValueError):
+    #         self.C.setParams(np.array([0]))
+    #
+    #     with self.assertRaises(ValueError):
+    #         self.C.K_grad_i(0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/limix/core/covar/test/test_categorical.py
+++ b/limix/core/covar/test/test_categorical.py
@@ -5,10 +5,10 @@ import numpy as np
 from limix.core.covar import Categorical
 from limix.utils.check_grad import mcheck_grad
 
-class TestCategorical(unittest.TestCase):
+class TestCategoricalLowRank(unittest.TestCase):
     """test class for Categorical cov"""
     def setUp(self):
-        # sp.random.seed(1)
+        sp.random.seed(1)
         self.n = 30
         categories = sp.random.choice(['a', 'b', 'c'], self.n)
 
@@ -43,6 +43,33 @@ class TestCategorical(unittest.TestCase):
     #
     #     with self.assertRaises(ValueError):
     #         self.C.K_grad_i(0)
+
+class TestCategoricalFreeForm(unittest.TestCase):
+    """test class for Categorical cov"""
+    def setUp(self):
+        sp.random.seed(1)
+        self.n = 30
+        categories = sp.random.choice(['a', 'b', 'c'], self.n)
+
+        self.rank =None
+
+        self.C = Categorical(categories,self.rank)
+        self.name = 'categorical'
+        self.C.setRandomParams()
+
+    def test_grad(self):
+        def func(x, i):
+            self.C.setParams(x)
+            return self.C.K()
+
+        def grad(x, i):
+            self.C.setParams(x)
+            return self.C.K_grad_i(i)
+
+        x0 = self.C.getParams()
+        err = mcheck_grad(func, grad, x0)
+
+        np.testing.assert_almost_equal(err, 0., decimal = 6)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
added a categorical covariance to model covariance between data with discrete labels, based on either free form or low rank covariance.

typically, cov_{i, j} = \sigma_c^2 if i and j from same category, \rho \sigma_c1 \sigma_c2 otherwise 